### PR TITLE
group on schema; add table_owner; fix more than one property

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,3 +188,4 @@ GeneratedArtifacts/
 _Pvt_Extensions/
 ModelManifest.xml
 *.nupkg
+/.vs/EfSchemaCompare/v15/Server/sqlite3

--- a/CompareCore/SqlInfo/SqlAllInfo.cs
+++ b/CompareCore/SqlInfo/SqlAllInfo.cs
@@ -40,13 +40,15 @@ namespace CompareCore.SqlInfo
             var allTablesAndCol = SqlTableAndColumnData.GetSqlTablesAndColumns(connection);
             var allForeignKeys = SqlForeignKey.GetForeignKeys(connection);
 
-            var tableInfos = from tableGroup in allTablesAndCol.GroupBy(x => x.TableName)
+            var tableInfos = from tableGroup in allTablesAndCol.GroupBy(x => $"{x.SchemaName}{x.TableName}")
                 let schemaName = tableGroup.First().SchemaName
-                let primaryKey = SqlPrimaryKey.GetPrimaryKeysNames(connection, tableGroup.Key)
+                let tableName = tableGroup.First().TableName
+                let primaryKey = SqlPrimaryKey.GetPrimaryKeysNames(connection, tableName, schemaName)
                 select (new SqlTableInfo(schemaName,
-                    tableGroup.Key, tableGroup.Select(y => new SqlColumnInfo(y.ColumnName, y.SqlTypeName,
+                    tableName, tableGroup.Select(y => new SqlColumnInfo(y.ColumnName, y.SqlTypeName,
                         primaryKey.SingleOrDefault(z => z.ColumnName == y.ColumnName),
                         y.IsNullable, y.MaxLength)).ToList()));
+
 
             var allIndexes = SqlIndex.GetAllIndexes(connection);
 

--- a/CompareCore/SqlInfo/SqlPrimaryKey.cs
+++ b/CompareCore/SqlInfo/SqlPrimaryKey.cs
@@ -29,7 +29,7 @@ namespace CompareCore.SqlInfo
         public Int16 KeyOrder { get; private set; }
         public string PrimaryKeyConstraintName { get; private set; }
 
-        public static IList<SqlPrimaryKey> GetPrimaryKeysNames(string connectionString, string tableName)
+        public static IList<SqlPrimaryKey> GetPrimaryKeysNames(string connectionString, string tableName, string schema)
         {
             var result = new Collection<SqlPrimaryKey>();
             using (var sqlcon = new SqlConnection(connectionString))
@@ -37,12 +37,19 @@ namespace CompareCore.SqlInfo
                 var command = sqlcon.CreateCommand();
 
                 //see https://msdn.microsoft.com/en-us/library/ms190196.aspx
-                command.CommandText = @"sp_pkeys @TableName";
-                var param = new SqlParameter();
-                param.ParameterName = "@TableName";
-                param.Value = tableName;
+                command.CommandText = @"sp_pkeys @TableName, @table_owner";
+                var param = new SqlParameter
+                {
+                    ParameterName = "@TableName",
+                    Value = tableName
+                };
                 command.Parameters.Add(param);
-
+                param = new SqlParameter
+                {
+                    ParameterName = "@table_owner",
+                    Value = schema
+                };
+                command.Parameters.Add(param);
                 sqlcon.Open();
                 using (var reader = command.ExecuteReader())
                 {

--- a/Ef6Compare/InternalEf6/Ef6MetadataDecoder.cs
+++ b/Ef6Compare/InternalEf6/Ef6MetadataDecoder.cs
@@ -116,13 +116,22 @@ namespace Ef6SchemaCompare.InternalEf6
         {
             // NOTE: EF can access non-public properties if the developer sets up EF that way, so we need to search both public and non public
             // See NonPublicColumnAttributeConvention in Ef6TestDbContext project for an example of that
-            var foundProperty = classToScan.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
-                .SingleOrDefault(x => x.Name == propertyName);
-            if (foundProperty == null)
+            var foundProperties = classToScan.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+                .Where(x => x.Name == propertyName).ToList();
+            if (foundProperties == null)
                 throw new InvalidOperationException(string.Format("Failed to find property called {0} in class {1}.",
                     propertyName, classToScan.Name));
+            if (foundProperties.Count() == 1)
+            {
+                return foundProperties.First();
+            }
+            else
+            {
+                // should we check if it is the first field?
+                return foundProperties.First();
+            }
 
-            return foundProperty;
+            // return foundProperty;
         }
 
         //--------------------------------------------------------------------------


### PR DESCRIPTION
group on schema and table name to avoid duplicates when more schema's has the same table name; 
add table_owner to GetPrimaryKeysNames to get pk's from other scheam's than dbo; 
fix returning more than one property on GetProperties when inherited classes with same property names